### PR TITLE
refactor: replace direct script access with getSporeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # misc
 .DS_Store
+/.idea
 *.pem
 
 # debug

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-lib/
+/lib

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spore-graphql",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A Graphql Layer designed to simplify Spore data queries",
   "type": "module",
   "module": "./lib/index.js",
@@ -21,7 +21,7 @@
     "dev": "tsc --watch --project tsconfig.build.json",
     "build": "tsc --project tsconfig.build.json",
     "generate": "graphql-codegen",
-    "prepublish": "npm run generate && npm run build"
+    "prepublish": "pnpm run generate && pnpm run build"
   },
   "dependencies": {
     "@apollo/server": "^4.9.5",
@@ -32,7 +32,8 @@
     "dataloader": "^2.2.2",
     "graphql": "^16.8.1",
     "graphql-tag": "^2.12.6",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.17.21",
+    "typescript": "^5.2.2"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
     devDependencies:
       '@graphql-codegen/cli':
         specifier: ^5.0.0
@@ -6099,7 +6102,6 @@ packages:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /ua-parser-js@1.0.37:
     resolution: {integrity: sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==}

--- a/src/data-sources/clusters.ts
+++ b/src/data-sources/clusters.ts
@@ -1,13 +1,13 @@
 import DataLoader from 'dataloader';
 import { Cell, helpers } from '@ckb-lumos/lumos';
-import { unpackToRawClusterData } from '@spore-sdk/core';
+import { unpackToRawClusterData, getSporeScript } from '@spore-sdk/core';
 import { encodeToAddress, isAnyoneCanPay, isSameScript } from '../utils';
 import { BaseDataSource } from './base';
 import { IClustersDataSource } from './interface';
 import { Cluster, ClusterLoadKey } from './types';
 
 export class ClustersDataSource extends BaseDataSource implements IClustersDataSource {
-  public script = this.config.scripts.Cluster.script;
+  public script = getSporeScript(this.config, 'Cluster').script;
 
   public static getClusterFromCell(cell: Cell): Cluster {
     const rawClusterData = unpackToRawClusterData(cell.data);

--- a/src/data-sources/spores.ts
+++ b/src/data-sources/spores.ts
@@ -1,5 +1,5 @@
 import DataLoader from 'dataloader';
-import { unpackToRawSporeData } from '@spore-sdk/core';
+import { getSporeScript, unpackToRawSporeData } from '@spore-sdk/core';
 import { Cell } from '@ckb-lumos/lumos';
 import { BaseDataSource } from './base';
 import { ISporesDataSource } from './interface';
@@ -7,7 +7,7 @@ import { Spore, SporeLoadKey } from './types';
 import { encodeToAddress } from '../utils';
 
 export class SporesDataSource extends BaseDataSource implements ISporesDataSource {
-  public script = this.config.scripts.Spore.script;
+  public script = getSporeScript(this.config, 'Spore').script;
 
   public static getSporeFromCell(cell: Cell): Spore {
     const rawSporeData = unpackToRawSporeData(cell.data);


### PR DESCRIPTION
Accessing `SporeConfig.scripts.xxx` directly may lead to issues when using different versions of the spore-sdk.
Replacing them with the `getSporeScript` API should resolve the issue for now.