### PR TITLE
refactor: move spore-sdk as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@as-integrations/next": "^3.0.0",
     "@ckb-lumos/lumos": "^0.22.0-next.3",
     "@ckb-lumos/config-manager": "^0.22.0-next.3",
-    "@spore-sdk/core": "^0.2.0-beta.1",
     "dataloader": "^2.2.2",
     "graphql": "^16.8.1",
     "graphql-tag": "^2.12.6",
@@ -39,5 +38,8 @@
     "@graphql-codegen/cli": "^5.0.0",
     "@graphql-codegen/typescript-resolvers": "^4.0.1",
     "@types/lodash-es": "^4.17.11"
+  },
+  "peerDependencies": {
+    "@spore-sdk/core": "^0.2.0-beta.1"
   }
 }


### PR DESCRIPTION
No changes in the lock file, simply moved the `@spore-sdk/core` from `dependencies` to `peerDependencies`.