### PR TITLE
bug: fix an OmniLock equality issue

### DIFF
--- a/.changeset/old-squids-press.md
+++ b/.changeset/old-squids-press.md
@@ -2,4 +2,4 @@
 'spore-graphql': patch
 ---
 
-Fix missing length check when unpacking omnilock flag
+Fix missing length check when unpacking omnilock flag and Omni script comparing logic

--- a/lib/src/data-sources/clusters.ts
+++ b/lib/src/data-sources/clusters.ts
@@ -1,7 +1,7 @@
 import DataLoader from 'dataloader';
 import { Cell, helpers } from '@ckb-lumos/lumos';
 import { unpackToRawClusterData, getSporeScriptCategory } from '@spore-sdk/core';
-import { encodeToAddress, isAnyoneCanPay, isSameScript, hashKeys } from '../utils';
+import { isAnyoneCanPay, isSameScript, hashKeys, ScriptEqualDeepCheck } from '../utils';
 import { BaseDataSource } from './base';
 import { IClustersDataSource } from './interface';
 import { Cluster, ClusterLoadKeys } from './types';
@@ -40,13 +40,14 @@ export class ClustersDataSource extends BaseDataSource implements IClustersDataS
 
             const cluster = ClustersDataSource.getClusterFromCell(cell);
 
-            // check the address of the cluster
-            if (
-              addresses &&
-              addresses.length > 0 &&
-              !addresses.includes(encodeToAddress(cluster.cell.cellOutput.lock, this.config))
-            ) {
-              continue;
+            if (addresses && addresses.length > 0) {
+              // check the address of the cluster
+              const find = addresses
+                .map((address) => helpers.parseAddress(address, { config: this.config.lumos }))
+                .find((lock) => ScriptEqualDeepCheck(lock, cluster.cell.cellOutput.lock, this.config));
+              if (find === void 0) {
+                continue;
+              }
             }
 
             // check the mintableBy of the cluster

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -34,6 +34,19 @@ export function isOmnilockScript(script: Script, config: SporeConfig) {
   return script.codeHash === omnilockScript.CODE_HASH && script.hashType === omnilockScript.HASH_TYPE;
 }
 
+export function ScriptEqualDeepCheck(script_a: Script, script_b: Script, config: SporeConfig) {
+  const omni_a = isOmnilockScript(script_a, config);
+  const omni_b = isOmnilockScript(script_b, config);
+  if (omni_a !== omni_b) {
+    return false;
+  }
+  if (omni_a && omni_b) {
+    return script_a.args.slice(0, 42) == script_b.args.slice(0, 42);
+  } else {
+    return script_a === script_b;
+  }
+}
+
 export function isAnyoneCanPayScript(script: Script, config: SporeConfig<string>) {
   const anyoneCanPayLockScript = getScriptConfig('ANYONE_CAN_PAY', config);
   if (!anyoneCanPayLockScript) {


### PR DESCRIPTION
# Description
if users use their default Omni lock as CKB address to search their owned Cluster cell that is created on Omni-ACP lock, the result is empty.

# Related Issues
- [x] #15 